### PR TITLE
Implement FDR calculation

### DIFF
--- a/cudaGSEA/src/cudaGSEA_wrapper.cpp
+++ b/cudaGSEA/src/cudaGSEA_wrapper.cpp
@@ -191,7 +191,7 @@ RcppExport SEXP GSEA(SEXP exprsData,
             auto minimum = +std::numeric_limits<proxy_value_t>::infinity();
 
             for (const auto& value : exprs_table) {
-                if(isnan(value)) {
+                if(std::isnan(value)) {
                     std::cout << "INVALID DATA: expression table has NaN "
                               << "entries that cannot be handled by the GSEA "
                               << "algorithm." << std::endl;

--- a/cudaGSEA/src/include/batched_sort.cuh
+++ b/cudaGSEA/src/include/batched_sort.cuh
@@ -21,6 +21,7 @@
 #include <omp.h>
 #endif
 
+#include <numeric>
 
 #ifdef UNIT_TEST
 // error makro

--- a/cudaGSEA/src/include/cugsea.cuh
+++ b/cudaGSEA/src/include/cugsea.cuh
@@ -252,6 +252,7 @@ void compute_gsea_gpu(
                   << " NES: "  << result[1*num_paths+path]
                   << " NP: "   << result[2*num_paths+path]
                   << " FWER: " << result[3*num_paths+path]
+                  << " FDR: "  << result[4*num_paths+path]
                   << "\t(" << pname[path] << ")" << std::endl;
     }
 
@@ -440,6 +441,7 @@ void compute_gsea_cpu(
                   << " NES: "  << result[1*num_paths+path]
                   << " NP: "   << result[2*num_paths+path]
                   << " FWER: " << result[3*num_paths+path]
+                  << " FDR: " <<  result[4*num_paths+path]
                   << "\t(" << pname[path] << ")" << std::endl;
     }
 

--- a/cudaGSEA/src/include/statistics.cuh
+++ b/cudaGSEA/src/include/statistics.cuh
@@ -43,6 +43,88 @@ index_t two_tail_count(const enrch_t * data,
     return counter;
 }
 
+template <class enrch_t, class index_t>
+enrch_t compute_fdr_q(const enrch_t * scores,
+                      const enrch_t * random_scores,
+                      const index_t num_paths,
+                      const index_t num_perms,
+                      const index_t index_to_ignore,  // index of random scores corresponding to score
+                      const enrch_t score) {
+
+    // more extreme than observed NES* in sets (S)
+    enrch_t more_extreme_observed = 0;
+    // number of S such that NES(S) ≥ 0 when NES* ≥ 0 [or such that NES(S) ≤ 0 when NES* ≤ 0]
+    enrch_t considered_sets = 0;
+
+    // more extreme than observed NES* in all permutations π (that are being considered for the positive/negative score)
+    enrch_t more_extreme_random_total = 0;
+    // temporary: more extreme than observed NES* in permutations π of gene set S
+    enrch_t more_extreme_random = 0;
+    // temporary: count of all π for given S with NES(S, π) ≥ 0 [or NES(S) ≤ 0]
+    enrch_t random_count = 0;
+    // count of all S with π such that there is at least one NES(S, π) ≥ 0 [or NES(S) ≤ 0]
+    enrch_t non_empty_sets_count = 0;
+
+    for (index_t other = 0; other < num_paths; other++) {
+
+        if (score >= 0) {
+
+            // count of NES(S, π) such that: NES(S, π) ≥ NES*
+            more_extreme_random = pos_tail_count(&random_scores[other*num_perms], num_perms, score);
+
+            // count of π for given S, such that NES(S, π) ≥ 0
+            random_count = pos_tail_count(&random_scores[other*num_perms], num_perms, (enrch_t) 0.0);
+
+            // count NES(S) such that NES(S) ≥ NES*
+            if (scores[other] >= score)
+                more_extreme_observed++;
+
+            // count of observed S with NES(S) ≥ 0
+            if (scores[other] >= 0)
+                considered_sets++;
+        }
+        else if (score < 0) {
+            more_extreme_random = neg_tail_count(&random_scores[other*num_perms], num_perms, score);
+
+            random_count = neg_tail_count(&random_scores[other*num_perms], num_perms, (enrch_t) 0.0);
+
+            if (scores[other] <= score)
+                more_extreme_observed++;
+
+            if (scores[other] <= 0)
+                considered_sets++;
+        }
+
+        if (random_count != 0) {
+            non_empty_sets_count++;
+            more_extreme_random_total += more_extreme_random / random_count;
+        }
+
+    }
+
+    // the percentage of all (S, π) with NES(S, π) ≥ 0, whose NES(S, π) ≥ NES*,
+    enrch_t numerator = more_extreme_random_total / non_empty_sets_count;
+    // the percentage of observed S with NES(S) ≥ 0, whose NES(S) ≥ NES*
+    enrch_t denominator = more_extreme_observed / considered_sets;
+
+    if (denominator == 0)
+        return 0;
+    else
+    {
+        enrch_t q = numerator / denominator;
+
+        // q-value is an estimate of FDR so it does not have to be strictly lower than 1;
+        // both GSEArot and gsea-desktop trim q-value at one, so let's do the same:
+
+        if(q > 1)
+            return 1;
+
+        return q;
+    }
+
+}
+
+
 template <class enrch_t, class index_t> __host__
 std::vector<enrch_t> final_statistics(std::vector<enrch_t>& enrchScores,
                                       const index_t num_paths,
@@ -58,15 +140,50 @@ std::vector<enrch_t> final_statistics(std::vector<enrch_t>& enrchScores,
 
     // now compute the normalized enrichment score for each path
     for (index_t path = 0; path < num_paths; path++) {
-        enrch_t sum = 0;
+        enrch_t sum_positive = 0;
+        enrch_t sum_negative = 0;
+        enrch_t cnt_positive = 0;
+        enrch_t cnt_negative = 0;
+
         // TODO: maybe make this Kahan stable
+        for (index_t perm = 0; perm < num_perms; perm++) {
+            enrch_t value = enrchScores[path*num_perms+perm];
+            if (value > 0) {
+                sum_positive += value;
+                cnt_positive++;
+            }
+            else {
+                sum_negative -= value;
+                cnt_negative++;
+            }
+        }
+
+        enrch_t factor_positive = cnt_positive / sum_positive;
+        enrch_t factor_negative = cnt_negative / sum_negative;
+
+        if (result[path] >= 0)
+            result[1*num_paths+path] = result[path] * factor_positive;
+        else
+            result[1*num_paths+path] = result[path] * factor_negative;
+
+        // dump to result:
+        // a memory-saving trick (this is not the final purpose of these columns)
+        result[3*num_paths+path] = factor_positive;
+        result[4*num_paths+path] = factor_negative;
+
+
+        // Interestingly, the joined-normalisation produced results
+        // closer to those from GSEA desktop in some comparisons...
+        // leaving the code here for now - just in case.
+        /*
+        enrch_t sum = 0;
         for (index_t perm = 0; perm < num_perms; perm++)
             sum += std::abs(enrchScores[path*num_perms+perm]);
-
-        // dump to result
         enrch_t factor = num_perms / sum;
         result[1*num_paths+path] = result[path]*factor;
         result[3*num_paths+path] = factor;
+        result[4*num_paths+path] = factor;
+        */
     }
 
     // compute nominal p-values for each path
@@ -83,11 +200,19 @@ std::vector<enrch_t> final_statistics(std::vector<enrch_t>& enrchScores,
 
     // renormalize all enrichment scores and determine extrema
     for (index_t path = 0; path < num_paths; path++) {
-        enrch_t factor = result[3*num_paths+path];
+        enrch_t factor_positive = result[3*num_paths+path];
+        enrch_t factor_negative = result[4*num_paths+path];
+
         for (index_t perm = 0; perm < num_perms; perm++) {
 
+            enrch_t value = enrchScores[path*num_perms+perm];
+
             // normalize enrichment scores
-            enrch_t value = enrchScores[path*num_perms+perm]*factor;
+            if (value >= 0)
+                value *= factor_positive;
+            else
+                value *= factor_negative;
+
             enrchScores[path*num_perms+perm] = value;
 
             // update extrema
@@ -106,46 +231,24 @@ std::vector<enrch_t> final_statistics(std::vector<enrch_t>& enrchScores,
         else
             p_value = neg_tail_count(min_vals.data(), num_perms, score);
 
+        // not by num_perms but by tail size
         result[3*num_paths+path] = p_value/num_perms;
     }
 
-    // FDR-Q: computed for all scores. Please note that GSEADesktop:
-    //  - calculates FDR per positive / negative scores separately,
-    //  - has some kind of a procedure designed for "skewed FDR"
-    // and while the code below does not attempt to reproduce GSEADesktop
-    // behaviour, it produces not much different scores.
+    // FDR-Q: computed for all scores.
     for (index_t path = 0; path < num_paths; path++) {
+
         // normalized enrichment score
         enrch_t score = result[num_paths+path];
-        enrch_t more_extreme_observed = 0;
-        enrch_t more_extreme_random = 0;
 
-        for (index_t other = 0; other < num_paths; other++) {
-            if (path == other)
-                continue;
-
-            if (score == 0) {
-                continue;
-            }
-            else if (score > 0) {
-                more_extreme_random += pos_tail_count(&enrchScores[other*num_perms], num_perms, score);
-                if (result[num_paths+other] >= score)
-                    more_extreme_observed += 1;
-            }
-            else {
-                more_extreme_random += neg_tail_count(&enrchScores[other*num_perms], num_perms, score);
-                if (result[num_paths+other] <= score)
-                    more_extreme_observed += 1;
-            }
-
-        }
-        enrch_t nominator = more_extreme_random / ((num_paths - 1) * num_perms);
-        enrch_t denominator = more_extreme_observed / (num_paths - 1);
-
-        if (denominator == 0)
-            result[4*num_paths+path] = 0;
-        else
-            result[4*num_paths+path] = nominator / denominator;
+        result[4*num_paths+path] = compute_fdr_q(
+            &result[num_paths],       // real scores
+            enrchScores.data(),       // random scores
+            num_paths,
+            num_perms,
+            path,
+            score
+        );
     }
 
     return result;

--- a/cudaGSEA/src/include/statistics.cuh
+++ b/cudaGSEA/src/include/statistics.cuh
@@ -109,7 +109,11 @@ std::vector<enrch_t> final_statistics(std::vector<enrch_t>& enrchScores,
         result[3*num_paths+path] = p_value/num_perms;
     }
 
-    // FDR-Q
+    // FDR-Q: computed for all scores. Please note that GSEADesktop:
+    //  - calculates FDR per positive / negative scores separately,
+    //  - has some kind of a procedure designed for "skewed FDR"
+    // and while the code below does not attempt to reproduce GSEADesktop
+    // behaviour, it produces not much different scores.
     for (index_t path = 0; path < num_paths; path++) {
         // normalized enrichment score
         enrch_t score = result[num_paths+path];


### PR DESCRIPTION
Hi @gravitino,

First off, thank you for maintaining this package!

During my MRes project I implemented FDR calculation for cudaGSEA. I was wondering if you are interested in merging my changes in. I have tested the results against the GSEADesktop (from Broad Institute) and it looks quite good (the grey line is the GSEADesktop FDR; `cuda_full_fdr` - the second facet - is the implementation that I propose in this PR):

![cuda_gsea_benchmark](https://user-images.githubusercontent.com/5832902/57011400-62324080-6bf9-11e9-839b-f049e466147a.png)

I also implemented an "approximate" FDR procedure (one-sided, please see [with_approximate_fdr](https://github.com/krassowski/cudaGSEA/tree/with_approximate_fdr) branch, here is [the diff](https://github.com/krassowski/cudaGSEA/compare/master...krassowski:with_approximate_fdr)) which is slightly faster but is not a part of this PR. The other branch also comes with a command line option for switching the FDR calculation - I can include it in this PR if you wish.

Please let me know what you think - I may be able to find some time to polish the code if you consider it worth merging.